### PR TITLE
Disable the button backlight settings

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -335,4 +335,7 @@
     -->
      <bool name="config_proximityCheckOnWake">true</bool>
 
+    <!-- Disables Button backlight settings -->
+    <integer name="config_buttonBrightnessSettingDefault">0</integer>
+
 </resources>


### PR DESCRIPTION
ZF2's hardware buttons do not have a backlight
