### PR TITLE
Keep Interactive tunables after profile switch.

### DIFF
--- a/rootdir/etc/init.power.mofd_v1.rc
+++ b/rootdir/etc/init.power.mofd_v1.rc
@@ -69,6 +69,12 @@ on property:sys.perf.profile=1
     write /sys/devices/system/cpu/cpu2/cpufreq/scaling_governor interactive
     write /sys/devices/system/cpu/cpu3/cpufreq/scaling_governor interactive
     setprop sys.perf.profile.device full,${ro.cm.device}
+    write /sys/devices/system/cpu/cpufreq/interactive/go_hispeed_load 50
+    write /sys/devices/system/cpu/cpufreq/interactive/min_sample_time 40000
+    write /sys/devices/system/cpu/cpufreq/interactive/target_loads "85 1500000:90 1800000:70"
+    write /sys/devices/system/cpu/cpufreq/interactive/timer_rate 30000
+    write /sys/devices/system/cpu/cpufreq/interactive/timer_slack 30000
+    write /sys/devices/system/cpu/cpufreq/interactive/touchboostpulse_duration 20000
     write /sys/devices/platform/dfrgx/devfreq/dfrgx/governor simple_ondemand
 
 # High performance


### PR DESCRIPTION
When switching between power profiles -or governors- the phone seems to forget the Interactive governor tunables. They should come back when the user switches to balanced mode.
