### PR TITLE
init mofd remove system in group mediaserver

### DIFF
--- a/rootdir/etc/init.mofd_v1.rc
+++ b/rootdir/etc/init.mofd_v1.rc
@@ -438,7 +438,7 @@ service cdrom /system/bin/sh /system/etc/init.cdrom.sh
 service_redefine media /system/bin/mediaserver
     class main
     user media
-    group audio camera inet net_bt net_bt_admin net_bw_acct drmrpc mediadrm radio system
+    group audio camera inet net_bt net_bt_admin net_bw_acct drmrpc mediadrm radio
     ioprio rt 4
 
 service_redefine keystore /system/bin/keystore /data/misc/keystore

--- a/rootdir/etc/init.mofd_v1.rc
+++ b/rootdir/etc/init.mofd_v1.rc
@@ -114,7 +114,7 @@ on boot
     setprop persist.service.cwsmgr.nortcoex 0
 
 # Set this property so surfaceflinger is not started by system_init
-    setprop system_init.startsurfaceflinger 0
+#    setprop system_init.startsurfaceflinger 0
 
 # Reboot in COS on shutdown request when charger is plugged
     setprop ro.rebootchargermode true


### PR DESCRIPTION
init mofd remove system in group media server as the commit here https://github.com/quanganh2627/android_device_intel_common/commit/5265638144e4d3dd97a80a4f787587c3da34e562  this system in system group in mediaserver is use for WIDI and Sync framework since we don't use WIDI may be we can try to remove this on group and test more if other will affect or give problem
